### PR TITLE
Push/Pop the PHP session in order to keep OC and DW separated.

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -13,7 +13,12 @@ class auth_plugin_authowncloud extends DokuWiki_Auth_Plugin {
    
 	public function __construct() {
 		parent::__construct();
+        $savedSession = session_name();
+        session_write_close();
 		require_once($this->getConf('pathtoowncloud').'/lib/base.php');
+        session_write_close();
+        session_name($savedSession);
+        session_start();
 		// Check if ownCloud is installed or in maintenance (update) mode
 		if (!OC_Config::getValue('installed', false)) {
 			global $conf;
@@ -260,9 +265,14 @@ class auth_plugin_authowncloud extends DokuWiki_Auth_Plugin {
     public function logOff(){
 		/* Doesn't work, i don't no why. If I run this 3 lines in an 
 		 * external script, it works. Within DokuWiki not */
+        $savedSession = session_name();
+        session_write_close();
 		session_name(OC_Util::getInstanceId());
 		session_start();
 		OC_User::logout();
+        session_write_close();
+        session_name($savedSession);
+        session_start();
 	}
 	
 	

--- a/auth.php
+++ b/auth.php
@@ -13,12 +13,23 @@ class auth_plugin_authowncloud extends DokuWiki_Auth_Plugin {
    
 	public function __construct() {
 		parent::__construct();
+
         $savedSession = session_name();
         session_write_close();
+        // one could argue about error_reportint() .... ;) However, we
+        // simply save and restore the settings active in
+        // owncloud. Otherwise the owncloud.log will be bloated with
+        // all kind of DW warnings
+        $savedReporting = error_reporting();
+
 		require_once($this->getConf('pathtoowncloud').'/lib/base.php');
+
+        error_reporting($savedReporting);
+        error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
         session_write_close();
         session_name($savedSession);
         session_start();
+
 		// Check if ownCloud is installed or in maintenance (update) mode
 		if (!OC_Config::getValue('installed', false)) {
 			global $conf;

--- a/manager.dat
+++ b/manager.dat
@@ -1,0 +1,3 @@
+installed=Mon, 18 Nov 2013 18:16:14 +0100
+url=https://github.com/rotdrop/dokuwiki-authowncloud/archive/master.zip
+updated=Mon, 18 Nov 2013 18:16:37 +0100


### PR DESCRIPTION
Dear Martin,

I already had contacted you by email concerning owncloud/dokuwiki integration. So here is a pull request from my side. At least in my setup with OC-5.0.13 this is needed to provied an SSO solution for an into-OC embedded DW instance, together with your DW oc-auth plugin. The idea of the patch is a push/pop strategy for PHP sessions.

Related to this pull-request is a "dokuwikiembed" OC-app. That one was inspired by the Roundcube-app, but avoids storing any password. The user authenticates at the time of its login with OC _and_ DW. The cookies returned by DW are then simply forwarded to the user's web-browser.

There is one caveat: my OC-DW-app authenticates with DW via XMLRPC, but there is no "logout" action defined (yet). Implementing such a method is fairly simple, but I still wait for any echo on the DW mailing list before publishing a patch.

Kind regards,

Claus
