### PR TITLE
Adding manager.dat was a stupid idea

### DIFF
--- a/manager.dat
+++ b/manager.dat
@@ -1,3 +1,0 @@
-installed=Mon, 18 Nov 2013 18:16:14 +0100
-url=https://github.com/rotdrop/dokuwiki-authowncloud/archive/master.zip
-updated=Mon, 18 Nov 2013 18:16:37 +0100


### PR DESCRIPTION
Sorry, but the manager.dat file with the wrong download URL only accidentally slipped into the git repo. This pull-request simply removes manager.dat from the repo, which simply restores the previous state.

Future pull requests will each "live" on dedicated branches, as should be.

Cheers,

Claus
